### PR TITLE
Alter deprecated Supply.more to Supply.emit

### DIFF
--- a/lib/Net/AMQP.pm6
+++ b/lib/Net/AMQP.pm6
@@ -152,7 +152,7 @@ method connect(){
 
                     my $frame = Net::AMQP::Frame.new($framebuf);
 
-                    $!frame-supply.more($frame);
+                    $!frame-supply.emit($frame);
                 } else {
                     $continue = False;
                 }

--- a/lib/Net/AMQP/Queue.pm6
+++ b/lib/Net/AMQP/Queue.pm6
@@ -227,7 +227,7 @@ method message-supply {
                     %headers<app-id> = $header-payload.app-id;
 
                     start {
-                    $s.more(Net::AMQP::Message.new(consumer-tag => $method.arguments[0],
+                    $s.emit(Net::AMQP::Message.new(consumer-tag => $method.arguments[0],
                                                    delivery-tag => $method.arguments[1],
                                                    redelivered => $method.arguments[2],
                                                    exchange-name => $method.arguments[3],


### PR DESCRIPTION
Hi,
Just having a play with the module with

This is perl6 version 2015.02-356-g412559b built on MoarVM version 2015.02-71-ga623b72

And was getting

   Saw 1 call to deprecated code during execution.
   ================================================================================
   Method more (from Supply) called at:
     lib/Net/AMQP.pm6, line 155
   Deprecated since v2014.10, will be removed with release v2015.10!
     lib/Net/AMQP/Queue.pm6, line 230
   Deprecated since v2014.10, will be removed with release v2015.10!
   Please use emit instead.

This fixes that.  Haven't worked out how to test for deprecations yet, otherwise I would have added a test.

Thanks for what could be a really useful module.
