### PR TITLE
Fix for deprecations

### DIFF
--- a/lib/Net/AMQP.pm6
+++ b/lib/Net/AMQP.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP;
+unit class Net::AMQP;
 
 use Net::AMQP::Frame;
 use Net::AMQP::Channel;

--- a/lib/Net/AMQP.pm6
+++ b/lib/Net/AMQP.pm6
@@ -159,10 +159,10 @@ method connect(){
             }
         },
         quit => {
-            $!vow.break(1);
+            $!vow.break("quit");
         },
         done => {
-            $!vow.break(1);
+            $!vow.break("done");
         });
         $!conn.write(buf8.new(65, 77, 81, 80, 0, 0, 9, 1));
     });

--- a/lib/Net/AMQP/Channel.pm6
+++ b/lib/Net/AMQP/Channel.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Channel;
+unit class Net::AMQP::Channel;
 
 use Net::AMQP::Exchange;
 use Net::AMQP::Queue;

--- a/lib/Net/AMQP/Exchange.pm6
+++ b/lib/Net/AMQP/Exchange.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Exchange;
+unit class Net::AMQP::Exchange;
 
 use Net::AMQP::Frame;
 use Net::AMQP::Payload::Method;

--- a/lib/Net/AMQP/Frame.pm6
+++ b/lib/Net/AMQP/Frame.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Frame;
+unit class Net::AMQP::Frame;
 
 use Net::AMQP::Payload::Body;
 use Net::AMQP::Payload::Header;

--- a/lib/Net/AMQP/Payload/ArgumentSerialization.pm6
+++ b/lib/Net/AMQP/Payload/ArgumentSerialization.pm6
@@ -1,4 +1,4 @@
-role Net::AMQP::Payload::ArgumentSerialization;
+unit role Net::AMQP::Payload::ArgumentSerialization;
 
 method serialize-arg($type, $value, $buf? is copy, $bitsused? = 0) {
     given $type {

--- a/lib/Net/AMQP/Payload/Body.pm6
+++ b/lib/Net/AMQP/Payload/Body.pm6
@@ -1,1 +1,1 @@
-class Net::AMQP::Payload::Body;
+unit class Net::AMQP::Payload::Body;

--- a/lib/Net/AMQP/Payload/Header.pm6
+++ b/lib/Net/AMQP/Payload/Header.pm6
@@ -1,6 +1,6 @@
 use Net::AMQP::Payload::ArgumentSerialization;
 
-class Net::AMQP::Payload::Header does Net::AMQP::Payload::ArgumentSerialization;
+unit class Net::AMQP::Payload::Header does Net::AMQP::Payload::ArgumentSerialization;
 
 has $.class-id;
 has $.weight = 0;

--- a/lib/Net/AMQP/Payload/Heartbeat.pm6
+++ b/lib/Net/AMQP/Payload/Heartbeat.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Payload::Heartbeat;
+unit class Net::AMQP::Payload::Heartbeat;
 
 method Buf {
     return buf8.new();

--- a/lib/Net/AMQP/Payload/Method.pm6
+++ b/lib/Net/AMQP/Payload/Method.pm6
@@ -1,6 +1,6 @@
 use Net::AMQP::Payload::ArgumentSerialization;
 
-class Net::AMQP::Payload::Method does Net::AMQP::Payload::ArgumentSerialization;
+unit class Net::AMQP::Payload::Method does Net::AMQP::Payload::ArgumentSerialization;
 
 my %standard = (
     connection =>

--- a/lib/Net/AMQP/Payload/Method.pm6
+++ b/lib/Net/AMQP/Payload/Method.pm6
@@ -89,7 +89,7 @@ method Buf {
     my $args = buf8.new();
     my $bitsused = 0;
     my $lastarg = '';
-    for @.signature Z @.arguments -> $arg, $value {
+    for (@.signature Z @.arguments).flat -> $arg, $value {
         if $arg ne 'bit' {
             $bitsused = 0;
         }

--- a/lib/Net/AMQP/Queue.pm6
+++ b/lib/Net/AMQP/Queue.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Queue;
+unit class Net::AMQP::Queue;
 
 use Net::AMQP::Payload::Method;
 use Net::AMQP::Frame;

--- a/t/01-connect.t
+++ b/t/01-connect.t
@@ -12,7 +12,7 @@ ok 1, 'can create Net::AMQP object';
 
 my $initial-promise = $n.connect;
 my $timeout = Promise.in(5);
-await Promise.anyof($initial-promise, $timeout);
+try await Promise.anyof($initial-promise, $timeout);
 unless $initial-promise.status == Kept {
     skip "Unable to connect. Please run RabbitMQ on localhost with default credentials.", 3;
     exit;

--- a/t/05-channel.t
+++ b/t/05-channel.t
@@ -10,7 +10,7 @@ my $n = Net::AMQP.new;
 
 my $initial-promise = $n.connect;
 my $timeout = Promise.in(5);
-await Promise.anyof($initial-promise, $timeout);
+try await Promise.anyof($initial-promise, $timeout);
 unless $initial-promise.status == Kept {
     skip "Unable to connect. Please run RabbitMQ on localhost with default credentials.", 7;
     exit;

--- a/t/10-exchange.t
+++ b/t/10-exchange.t
@@ -10,7 +10,7 @@ my $n = Net::AMQP.new;
 
 my $initial-promise = $n.connect;
 my $timeout = Promise.in(5);
-await Promise.anyof($initial-promise, $timeout);
+try await Promise.anyof($initial-promise, $timeout);
 unless $initial-promise.status == Kept {
     skip "Unable to connect. Please run RabbitMQ on localhost with default credentials.", 3;
     exit;

--- a/t/15-queue.t
+++ b/t/15-queue.t
@@ -10,7 +10,7 @@ my $n = Net::AMQP.new;
 
 my $initial-promise = $n.connect;
 my $timeout = Promise.in(5);
-await Promise.anyof($initial-promise, $timeout);
+try await Promise.anyof($initial-promise, $timeout);
 unless $initial-promise.status == Kept {
     skip "Unable to connect. Please run RabbitMQ on localhost with default credentials.", 2;
     exit;

--- a/t/20-integration.t
+++ b/t/20-integration.t
@@ -10,7 +10,7 @@ my $n = Net::AMQP.new;
 
 my $initial-promise = $n.connect;
 my $timeout = Promise.in(5);
-await Promise.anyof($initial-promise, $timeout);
+try await Promise.anyof($initial-promise, $timeout);
 unless $initial-promise.status == Kept {
     skip "Unable to connect. Please run RabbitMQ on localhost with default credentials.", 1;
     exit;


### PR DESCRIPTION
Hi,
using class/role/module in the semicolon form recently became deprecated in rakudo so one of these commits fixes that.

Also I noticed that the tests were exiting without doing the skip if the connection failed so I've added a try to the await.  

However there is another problem which I am still hunting down as it appears that the behaviour of IO::Socket::Async has changed between rakudo 2015.04 and rakudo 2015.05 which appears to cause the bytes_supply to quit before the response is received.  If I find the cause I'll raise another PR.
