### PR TITLE
Add unit declarator to class and role declarations

### DIFF
--- a/lib/Net/AMQP.pm6
+++ b/lib/Net/AMQP.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP;
+unit class Net::AMQP;
 
 use Net::AMQP::Frame;
 use Net::AMQP::Channel;

--- a/lib/Net/AMQP/Channel.pm6
+++ b/lib/Net/AMQP/Channel.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Channel;
+unit class Net::AMQP::Channel;
 
 use Net::AMQP::Exchange;
 use Net::AMQP::Queue;

--- a/lib/Net/AMQP/Exchange.pm6
+++ b/lib/Net/AMQP/Exchange.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Exchange;
+unit class Net::AMQP::Exchange;
 
 use Net::AMQP::Frame;
 use Net::AMQP::Payload::Method;

--- a/lib/Net/AMQP/Frame.pm6
+++ b/lib/Net/AMQP/Frame.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Frame;
+unit class Net::AMQP::Frame;
 
 use Net::AMQP::Payload::Body;
 use Net::AMQP::Payload::Header;

--- a/lib/Net/AMQP/Payload/ArgumentSerialization.pm6
+++ b/lib/Net/AMQP/Payload/ArgumentSerialization.pm6
@@ -1,4 +1,4 @@
-role Net::AMQP::Payload::ArgumentSerialization;
+unit role Net::AMQP::Payload::ArgumentSerialization;
 
 method serialize-arg($type, $value, $buf? is copy, $bitsused? = 0) {
     given $type {

--- a/lib/Net/AMQP/Payload/Body.pm6
+++ b/lib/Net/AMQP/Payload/Body.pm6
@@ -1,1 +1,1 @@
-class Net::AMQP::Payload::Body;
+unit class Net::AMQP::Payload::Body;

--- a/lib/Net/AMQP/Payload/Header.pm6
+++ b/lib/Net/AMQP/Payload/Header.pm6
@@ -1,6 +1,6 @@
 use Net::AMQP::Payload::ArgumentSerialization;
 
-class Net::AMQP::Payload::Header does Net::AMQP::Payload::ArgumentSerialization;
+unit class Net::AMQP::Payload::Header does Net::AMQP::Payload::ArgumentSerialization;
 
 has $.class-id;
 has $.weight = 0;

--- a/lib/Net/AMQP/Payload/Heartbeat.pm6
+++ b/lib/Net/AMQP/Payload/Heartbeat.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Payload::Heartbeat;
+unit class Net::AMQP::Payload::Heartbeat;
 
 method Buf {
     return buf8.new();

--- a/lib/Net/AMQP/Payload/Method.pm6
+++ b/lib/Net/AMQP/Payload/Method.pm6
@@ -1,6 +1,6 @@
 use Net::AMQP::Payload::ArgumentSerialization;
 
-class Net::AMQP::Payload::Method does Net::AMQP::Payload::ArgumentSerialization;
+unit class Net::AMQP::Payload::Method does Net::AMQP::Payload::ArgumentSerialization;
 
 my %standard = (
     connection =>

--- a/lib/Net/AMQP/Queue.pm6
+++ b/lib/Net/AMQP/Queue.pm6
@@ -1,4 +1,4 @@
-class Net::AMQP::Queue;
+unit class Net::AMQP::Queue;
 
 use Net::AMQP::Payload::Method;
 use Net::AMQP::Frame;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
