### PR TITLE
bytes_supply -> bytes-supply

### DIFF
--- a/lib/Net/AMQP.pm6
+++ b/lib/Net/AMQP.pm6
@@ -141,7 +141,7 @@ method connect(){
 
         my $buf = buf8.new();
 
-        $!conn.bytes_supply.act(-> $bytes {
+        $!conn.bytes-supply.act(-> $bytes {
             $buf ~= $bytes;
             my $continue = True;
             while $continue && $buf.bytes >= 7 {


### PR DESCRIPTION
Some time in the last few months IO::Socket::Async.bytes_supply became bytes-supply.
